### PR TITLE
fix: Missing #downloads anchor; link to #command-line-tools-only

### DIFF
--- a/guides/android_sdk_guia_de_instalacao.md
+++ b/guides/android_sdk_guia_de_instalacao.md
@@ -22,7 +22,7 @@ Se você tiver alguma dúvida ou sugestão, não hesite em me contatar através 
 ## Ferramentas de linha de comando
 
 - Abra a [página de download do android
-  sdk](https://developer.android.com/studio#downloads)
+  sdk](https://developer.android.com/studio#command-line-tools-only)
 - Pesquise por "Command line tools only"
 - Faça o download do pacote de ferramentas para o seu sistema
   operacional

--- a/guides/android_sdk_guia_de_instalacao.md
+++ b/guides/android_sdk_guia_de_instalacao.md
@@ -22,7 +22,7 @@ Se você tiver alguma dúvida ou sugestão, não hesite em me contatar através 
 ## Ferramentas de linha de comando
 
 - Abra a [página de download do android
-  sdk](https://developer.android.com/studio#command-line-tools-only)
+  sdk](https://developer.android.com/studio?hl=pt-br#somente-ferramentas-de-linha-de-comando)
 - Pesquise por "Command line tools only"
 - Faça o download do pacote de ferramentas para o seu sistema
   operacional

--- a/guides/android_sdk_install_guide.md
+++ b/guides/android_sdk_install_guide.md
@@ -20,7 +20,7 @@ If you have any questions or suggestions, feel free to contact me through my Git
 ## Command line tools
 
 - Go to [android sdk download
-  page](https://developer.android.com/studio#downloads)
+  page](https://developer.android.com/studio#command-line-tools-only)
 - Look for "Command line tools only"
 - Download the commandline tools for your operating system
 


### PR DESCRIPTION
Hey there @mesaquen! Thanks so much for writing up this guide! Google's Developer documentation is pretty confusingly structured; I read through it and ended up directly on their "downloads" (studio) page and still didn't find the command-line tools (which your guide helped me find and download!).

It seems the `#downloads` anchor just leaves you at the top pushing toward the "Download Android Studio Iguana" primary action, so this PR just changes the links in both guides to use the `#command-line-tools-only` anchor so it takes you directly to the "Command line tools only" section! 😊

Cheers!